### PR TITLE
fix(curriculumDetail): use correct type for item in subjectIds

### DIFF
--- a/src/models/Curriculum.tsx
+++ b/src/models/Curriculum.tsx
@@ -8,6 +8,15 @@ export interface Curriculum {
   startYear: number;
   endYear: number;
 }
+
+export interface SubjectInCurriculum {
+  subjectId: string;
+  curriculumId: string;
+  subjectCode: string;
+  subjectName: string;
+  id: string;
+}
+
 export interface CreateCurriculum {
   programId: string;
   curriculumCode: string;

--- a/src/pages/students/CurriculumDetailStudent.tsx
+++ b/src/pages/students/CurriculumDetailStudent.tsx
@@ -11,6 +11,7 @@ import { Curriculum } from "../../models/Curriculum";
 import { Program } from "../../models/Program";
 import { PLO } from "../../models/PO_PLO";
 import { Subject } from "../../models/Subject";
+import { SubjectInCurriculum } from "../../models/Curriculum";
 import { Link } from "react-router-dom";
 
 function CurriculumDetailStudent() {
@@ -59,8 +60,8 @@ function CurriculumDetailStudent() {
         const subjectIds = await getSubjectInCurriculumByCurriID(curriculumId);
 
         // Fetch each subject's details
-        const subjectPromises = subjectIds.map((item: Subject) =>
-          getSubjectByID(item.id),
+        const subjectPromises = subjectIds.map((item: SubjectInCurriculum) =>
+          getSubjectByID(item.subjectId),
         );
 
         const subjectData = await Promise.all(subjectPromises);

--- a/src/pages/students/SyllabusDetails.tsx
+++ b/src/pages/students/SyllabusDetails.tsx
@@ -54,7 +54,7 @@ function SyllabusDetails() {
   };
 
   // Function to format CLO ID (e.g., CLO1, CLO2, etc.)
-  const formatCLOId = (id: string, index: number) => {
+  const formatCLOId = (_id: string, index: number) => {
     return `CLO${index + 1}`;
   };
 


### PR DESCRIPTION
the returned data by api GET /SubjectInCurriculum/curriculum/{curriculumId} is not like Subjects type defined in models

need to define another type SubjectInCurriculum interface to satisfied the type

use subjectIds from that data to fetch into GetSubjects